### PR TITLE
bugfix: use Numbers instead of BigInt in approve method

### DIFF
--- a/src/dca_frontend/src/components/AuthModalButtons/AuthModalButtons.tsx
+++ b/src/dca_frontend/src/components/AuthModalButtons/AuthModalButtons.tsx
@@ -29,7 +29,6 @@ const AuthModalButtons: React.FC = () => {
                 setAuthClient(client);
                 const identity = client.getIdentity();
                 const actorBackend = await createActor(whitelist[1], backend, identity);
-                console.log(actorBackend);
                 const actorLedger = await createActor(whitelist[2], legger, identity);
 
                 setActorBackend(actorBackend);

--- a/src/dca_frontend/src/components/OpenPosition/OpenPosition.tsx
+++ b/src/dca_frontend/src/components/OpenPosition/OpenPosition.tsx
@@ -91,9 +91,7 @@ const OpenPosition: React.FC<OpenPositionProps> = ({
 
             const allowanceInNumber = Number(allowanceResult.allowance);
 
-            const totalPurchasesAmmount =
-                (BigInt(amount) * BigInt(100000000) + BigInt(10_000)) * BigInt(numberOfPayments) +
-                BigInt(allowanceInNumber);
+            const totalPurchasesAmmount = (amount * 100000000 + 10_000) * numberOfPayments + allowanceInNumber;
 
             const approveArgs = {
                 amount: totalPurchasesAmmount,


### PR DESCRIPTION
Fix approve method: replace BigInts with Numbers, because of impossibility of using float with BigInt

